### PR TITLE
Rename Biliniar to bilinear and add default to bilinear interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ logarithmic spaced values.
  - added type aliases for common interpolators
  - make the `VectorExtensions` trait public
  - add `Interp1D::new_unchecked` and `Interp2D::new_unchecked` methods
- - add biliniar extrapolation
+ - add bilinear extrapolation
  - impl `Default` for interpolation strategies
 
 # 0.3.0
  - add 2d interpolation
- - add biliniar interpolation strategy
+ - add bilinear interpolation strategy
  - rename `Strategy` to `Interp1DStrategy` and `StrategyBuilder` to `Interp1DStrategyBuilder`
  - make extrapolate filed of `Linear` private add `extrapolate(bool)` method instead.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "Interpolation package for ndarray"
 repository = "https://github.com/jonasBoss/ndarray-interp"
 
-keywords = ["interpolation", "multidimensional", "liniar", "biliniar", "cubic-spline"]
+keywords = ["interpolation", "multidimensional", "linear", "bilinear", "cubic-spline"]
 categories = ["science", "algorithms", "mathematics"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Interpolation crate for usage with the rust [ndarray](https://crates.io/crates
 ## Interpolation strategies
  - Linear interpolation with, and without extrapolation
  - Cubic spline interpolation [Wikipedia](https://en.wikipedia.org/wiki/Spline_interpolation)
- - Biliniar interpolation with, and without extrapolation [Wikipedia](https://en.wikipedia.org/wiki/Bilinear_interpolation)
+ - Bilinear interpolation with, and without extrapolation [Wikipedia](https://en.wikipedia.org/wiki/Bilinear_interpolation)
 
 ## Planned Features
  - More interpolation strategies

--- a/benches/bench_interp2d_query_dim.rs
+++ b/benches/bench_interp2d_query_dim.rs
@@ -1,12 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ndarray::{Array, Array1, Axis};
-use ndarray_interp::interp2d::{Biliniar, Interp2D, Interp2DScalar};
+use ndarray_interp::interp2d::{Bilinear, Interp2D, Interp2DScalar};
 
 use rand_extensions::RandArray;
 
 mod rand_extensions;
 
-fn setup() -> (Interp2DScalar<f64, Biliniar>, Array1<f64>, Array1<f64>) {
+fn setup() -> (Interp2DScalar<f64, Bilinear>, Array1<f64>, Array1<f64>) {
     let data = Array::from_rand(10_000, (0.0, 1.0), 42)
         .into_shape((100, 100))
         .unwrap();

--- a/src/interp2d.rs
+++ b/src/interp2d.rs
@@ -9,7 +9,7 @@
 //!  - [`Interp2DStrategyBuilder`] The trait used to specialize [`Interp2DBuilder`] to initialize the correct strategy
 //!
 //! # Strategies
-//!  - [`Biliniar`] Linear interpolation strategy
+//!  - [`Bilinear`] Linear interpolation strategy
 
 use std::{any::TypeId, fmt::Debug, ops::Sub};
 
@@ -29,7 +29,7 @@ use crate::{
 mod aliases;
 mod strategies;
 pub use aliases::*;
-pub use strategies::{Biliniar, Interp2DStrategy, Interp2DStrategyBuilder};
+pub use strategies::{Bilinear, Interp2DStrategy, Interp2DStrategyBuilder};
 
 /// Two dimensional interpolator
 #[derive(Debug)]
@@ -47,7 +47,7 @@ where
     strategy: Strat,
 }
 
-impl<Sd, D> Interp2D<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Biliniar>
+impl<Sd, D> Interp2D<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Bilinear>
 where
     Sd: Data,
     Sd::Elem: Num + PartialOrd + NumCast + Copy + Debug + Sub + Send,
@@ -56,7 +56,7 @@ where
     /// Get the [Interp2DBuilder]
     pub fn builder(
         data: ArrayBase<Sd, D>,
-    ) -> Interp2DBuilder<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Biliniar> {
+    ) -> Interp2DBuilder<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Bilinear> {
         Interp2DBuilder::new(data)
     }
 }
@@ -379,7 +379,7 @@ where
     strategy: Strat,
 }
 
-impl<Sd, D> Interp2DBuilder<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Biliniar>
+impl<Sd, D> Interp2DBuilder<Sd, OwnedRepr<Sd::Elem>, OwnedRepr<Sd::Elem>, D, Bilinear>
 where
     Sd: Data,
     Sd::Elem: Num + PartialOrd + NumCast + Copy + Debug + Sub,
@@ -400,7 +400,7 @@ where
             x,
             y,
             data,
-            strategy: Biliniar::new(),
+            strategy: Bilinear::new(),
         }
     }
 }
@@ -416,7 +416,7 @@ where
     Strat: Interp2DStrategyBuilder<Sd, Sx, Sy, D>,
 {
     /// Set the interpolation strategy by provideing a [`Interp2DStrategyBuilder`].
-    /// By default [`Biliniar`] is used.
+    /// By default [`Bilinear`] is used.
     pub fn strategy<NewStrat: Interp2DStrategyBuilder<Sd, Sx, Sy, D>>(
         self,
         strategy: NewStrat,

--- a/src/interp2d/strategies.rs
+++ b/src/interp2d/strategies.rs
@@ -7,9 +7,9 @@ use crate::{BuilderError, InterpolateError};
 
 use super::Interp2D;
 
-mod biliniar;
+mod bilinear;
 
-pub use biliniar::Biliniar;
+pub use bilinear::Bilinear;
 
 pub trait Interp2DStrategyBuilder<Sd, Sx, Sy, D>
 where

--- a/src/interp2d/strategies/bilinear.rs
+++ b/src/interp2d/strategies/bilinear.rs
@@ -8,11 +8,11 @@ use crate::{interp1d::Linear, InterpolateError};
 use super::{Interp2DStrategy, Interp2DStrategyBuilder};
 
 #[derive(Debug)]
-pub struct Biliniar {
+pub struct Bilinear {
     extrapolate: bool,
 }
 
-impl<Sd, Sx, Sy, D> Interp2DStrategyBuilder<Sd, Sx, Sy, D> for Biliniar
+impl<Sd, Sx, Sy, D> Interp2DStrategyBuilder<Sd, Sx, Sy, D> for Bilinear
 where
     Sd: Data,
     Sd::Elem: Num + PartialOrd + NumCast + Copy + Debug + Sub + Send,
@@ -35,7 +35,7 @@ where
     }
 }
 
-impl<Sd, Sx, Sy, D> Interp2DStrategy<Sd, Sx, Sy, D> for Biliniar
+impl<Sd, Sx, Sy, D> Interp2DStrategy<Sd, Sx, Sy, D> for Bilinear
 where
     Sd: Data,
     Sd::Elem: Num + PartialOrd + NumCast + Copy + Debug + Sub + Send,
@@ -82,9 +82,9 @@ where
     }
 }
 
-impl Biliniar {
+impl Bilinear {
     pub fn new() -> Self {
-        Biliniar { extrapolate: false }
+        Bilinear { extrapolate: false }
     }
 
     pub fn extrapolate(mut self, yes: bool) -> Self {
@@ -93,7 +93,7 @@ impl Biliniar {
     }
 }
 
-impl Default for Biliniar {
+impl Default for Bilinear {
     fn default() -> Self {
         Self::new()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@ pub enum BuilderError {
 pub enum InterpolateError {
     #[error("{0}")]
     OutOfBounds(String),
+    #[error("{0}")]
+    InvalidArguments(String),
 }
 
 /// cast `a` from type `A` to type `B` without any safety checks


### PR DESCRIPTION
The first commit fixes the typo bilinier to bilinear and can be easily merged in. Although, you might want to add a type alias for backward compatibility and eventually deprecate it.  

The second enables the 2d bilinear interpolation strategy to return a default value if the query is out of bounds, like [scipy's fill_value](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html#scipy.interpolate.interp1d). This works as is, but there are a few limitations to the current implementation that I would like your feedback on:
- Returning a default value is currently handled by the `allow_default` boolean flag, meaning that there are some checks to ensure that both `extrapolate` and `allow_default` aren't both enabled simultaneously. Maybe a `BoundaryConditions` enum would be better?
- There's no way to specify what the default value should be, it simply uses `Default::default()` at the moment, but maybe a user would want the default to be something else. I tried enabling this by adding the `Sd` generic to the `Bilinear` struct and adding in a new field to capture what the default should be. I'm fairly new to Rust and have not yet been able to figure out all the correct trait bounds needed to pull this off. 
- Finally, this currently causes [jaggies](https://en.wikipedia.org/wiki/Jaggies) as there's no smooth interpolation between the data and default out-of-bounds value. This is tricky to solve given how the crate is implemented. It would require finding the neighboring pixels/data points to the out-of-bounds query and interpolate between the default value and any in-bounds neighbors. Since the actual coordinates are stored as `Vec`s this indirection layer makes this not as trivial as I originally thought. However, for default coordinates (where the index to coord mapping is just a range) this could be done more easily.

