### PR TITLE
Update ndarray dependency to v0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["science", "algorithms", "mathematics"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ndarray = "0.15"
+ndarray = "0.16"
 num-traits = "0.2"
 thiserror = "1.0"
 
 [dev-dependencies]
 cargo-tarpaulin = "0.27"
-ndarray = {version = "0.15", features = ["approx-0_5", "rayon"] }
+ndarray = {version = "0.16", features = ["approx", "rayon"] }
 approx = "0.5" 
 criterion = "0.5"
 rand = "0.8"

--- a/benches/bench_interp1d.rs
+++ b/benches/bench_interp1d.rs
@@ -67,7 +67,7 @@ fn bench_interp1d_scalar_multithread(c: &mut Criterion) {
         })
     });
 
-    let query = query.into_shape((2500, 4)).unwrap();
+    let query = query.into_shape_with_order((2500, 4)).unwrap();
     let query_arr: Vec<_> = query.axis_iter(Axis(0)).collect();
     c.bench_function("1D scalar MT `interp_array`", |b| {
         b.iter(|| {
@@ -80,7 +80,7 @@ fn bench_interp1d_scalar_multithread(c: &mut Criterion) {
 
 fn bench_interp1d_array(c: &mut Criterion) {
     let data = Array::from_rand(500, (0.0, 1.0), 69)
-        .into_shape((100, 5))
+        .into_shape_with_order((100, 5))
         .unwrap();
     let interp = Interp1D::builder(data).build().unwrap();
     let query = Array::from_rand(10_000, (0.0, 99.0), 123);
@@ -102,7 +102,7 @@ fn bench_interp1d_array(c: &mut Criterion) {
         })
     });
 
-    let query = query.into_shape((2500, 4)).unwrap();
+    let query = query.into_shape_with_order((2500, 4)).unwrap();
     let query_arr: Vec<_> = query.axis_iter(Axis(0)).collect();
     c.bench_function("1D array `interp_array`", |b| {
         b.iter(|| {

--- a/benches/bench_interp1d_query_dim.rs
+++ b/benches/bench_interp1d_query_dim.rs
@@ -13,7 +13,7 @@ fn bench_scalar_data_1d_query(c: &mut Criterion) {
     let interp = Interp1D::builder(data).build().unwrap();
     let query = Array::from_rand(10_000, (0.0, 99.0), 123);
 
-    let query = query.into_shape((2500, 4)).unwrap();
+    let query = query.into_shape_with_order((2500, 4)).unwrap();
     let query_arr: Vec<_> = query.axis_iter(Axis(0)).collect();
     c.bench_function("1D scalar `interp_array`", |b| {
         b.iter(|| {
@@ -38,7 +38,7 @@ fn bench_scalar_data_2d_query(c: &mut Criterion) {
     let interp = Interp1D::builder(data).build().unwrap();
     let query = Array::from_rand(10_000, (0.0, 99.0), 123);
 
-    let query = query.into_shape((625, 4, 4)).unwrap();
+    let query = query.into_shape_with_order((625, 4, 4)).unwrap();
     let query_arr: Vec<_> = query.axis_iter(Axis(0)).collect();
     c.bench_function("1D scalar `interp_array` 2D-query", |b| {
         b.iter(|| {
@@ -63,7 +63,7 @@ fn bench_scalar_data_3d_query(c: &mut Criterion) {
     let interp = Interp1D::builder(data).build().unwrap();
     let query = Array::from_rand(10_000, (0.0, 99.0), 123);
 
-    let query = query.into_shape((125, 5, 4, 4)).unwrap();
+    let query = query.into_shape_with_order((125, 5, 4, 4)).unwrap();
     let query_arr: Vec<_> = query.axis_iter(Axis(0)).collect();
     c.bench_function("1D scalar `interp_array` 3D-query", |b| {
         b.iter(|| {

--- a/benches/bench_interp2d.rs
+++ b/benches/bench_interp2d.rs
@@ -11,7 +11,7 @@ mod rand_extensions;
 
 fn bench_interp2d_scalar(c: &mut Criterion) {
     let data = Array::from_rand(10_000, (0.0, 1.0), 42)
-        .into_shape((100, 100))
+        .into_shape_with_order((100, 100))
         .unwrap();
     let interp = Interp2D::builder(data).build().unwrap();
     let query_x = Array::from_rand(10_000, (0.0, 99.0), 123);
@@ -45,7 +45,7 @@ fn bench_interp2d_scalar(c: &mut Criterion) {
 
 fn bench_interp2d_scalar_multithread(c: &mut Criterion) {
     let data = Array::from_rand(10_000, (0.0, 1.0), 42)
-        .into_shape((100, 100))
+        .into_shape_with_order((100, 100))
         .unwrap();
     let interp = Interp2D::builder(data).build().unwrap();
     let query_x = Array::from_rand(10_000, (0.0, 99.0), 123);
@@ -67,8 +67,8 @@ fn bench_interp2d_scalar_multithread(c: &mut Criterion) {
         })
     });
 
-    let query_x = query_x.into_shape((2500, 4)).unwrap();
-    let query_y = query_y.into_shape((2500, 4)).unwrap();
+    let query_x = query_x.into_shape_with_order((2500, 4)).unwrap();
+    let query_y = query_y.into_shape_with_order((2500, 4)).unwrap();
     let query_arrx: Vec<_> = query_x.axis_iter(Axis(0)).collect();
     let query_arry: Vec<_> = query_y.axis_iter(Axis(0)).collect();
     c.bench_function("2D scalar MT `interp_array`", |b| {
@@ -85,7 +85,7 @@ fn bench_interp2d_scalar_multithread(c: &mut Criterion) {
 
 fn bench_interp2d_array(c: &mut Criterion) {
     let data = Array::from_rand(50_000, (0.0, 1.0), 69)
-        .into_shape((100, 100, 5))
+        .into_shape_with_order((100, 100, 5))
         .unwrap();
     let interp = Interp2D::builder(data).build().unwrap();
     let query_x = Array::from_rand(10_000, (0.0, 99.0), 123);
@@ -108,8 +108,8 @@ fn bench_interp2d_array(c: &mut Criterion) {
         })
     });
 
-    let query_x = query_x.into_shape((2500, 4)).unwrap();
-    let query_y = query_y.into_shape((2500, 4)).unwrap();
+    let query_x = query_x.into_shape_with_order((2500, 4)).unwrap();
+    let query_y = query_y.into_shape_with_order((2500, 4)).unwrap();
     let query_arrx: Vec<_> = query_x.axis_iter(Axis(0)).collect();
     let query_arry: Vec<_> = query_y.axis_iter(Axis(0)).collect();
     c.bench_function("2D array `interp_array`", |b| {

--- a/benches/bench_interp2d_query_dim.rs
+++ b/benches/bench_interp2d_query_dim.rs
@@ -8,7 +8,7 @@ mod rand_extensions;
 
 fn setup() -> (Interp2DScalar<f64, Bilinear>, Array1<f64>, Array1<f64>) {
     let data = Array::from_rand(10_000, (0.0, 1.0), 42)
-        .into_shape((100, 100))
+        .into_shape_with_order((100, 100))
         .unwrap();
     let interp = Interp2D::builder(data).build().unwrap();
     let query_x = Array::from_rand(10_000, (0.0, 99.0), 123);
@@ -18,8 +18,8 @@ fn setup() -> (Interp2DScalar<f64, Bilinear>, Array1<f64>, Array1<f64>) {
 
 fn bench_scalar_data_1d_query(c: &mut Criterion) {
     let (interp, query_x, query_y) = black_box(setup());
-    let query_x = query_x.into_shape((2500, 4)).unwrap();
-    let query_y = query_y.into_shape((2500, 4)).unwrap();
+    let query_x = query_x.into_shape_with_order((2500, 4)).unwrap();
+    let query_y = query_y.into_shape_with_order((2500, 4)).unwrap();
     let query_arrx: Vec<_> = query_x.axis_iter(Axis(0)).collect();
     let query_arry: Vec<_> = query_y.axis_iter(Axis(0)).collect();
 
@@ -43,8 +43,8 @@ fn bench_scalar_data_1d_query(c: &mut Criterion) {
 
 fn bench_scalar_data_2d_query(c: &mut Criterion) {
     let (interp, query_x, query_y) = black_box(setup());
-    let query_x = query_x.into_shape((625, 4, 4)).unwrap();
-    let query_y = query_y.into_shape((625, 4, 4)).unwrap();
+    let query_x = query_x.into_shape_with_order((625, 4, 4)).unwrap();
+    let query_y = query_y.into_shape_with_order((625, 4, 4)).unwrap();
     let query_arrx: Vec<_> = query_x.axis_iter(Axis(0)).collect();
     let query_arry: Vec<_> = query_y.axis_iter(Axis(0)).collect();
 
@@ -68,8 +68,8 @@ fn bench_scalar_data_2d_query(c: &mut Criterion) {
 
 fn bench_scalar_data_3d_query(c: &mut Criterion) {
     let (interp, query_x, query_y) = black_box(setup());
-    let query_x = query_x.into_shape((125, 5, 4, 4)).unwrap();
-    let query_y = query_y.into_shape((125, 5, 4, 4)).unwrap();
+    let query_x = query_x.into_shape_with_order((125, 5, 4, 4)).unwrap();
+    let query_y = query_y.into_shape_with_order((125, 5, 4, 4)).unwrap();
     let query_arrx: Vec<_> = query_x.axis_iter(Axis(0)).collect();
     let query_arry: Vec<_> = query_y.axis_iter(Axis(0)).collect();
 

--- a/src/interp2d/mod.rs
+++ b/src/interp2d/mod.rs
@@ -265,7 +265,7 @@ where
                     }
                 });
 
-            let subview = match subview.into_shape(
+            let subview = match subview.into_shape_with_order(
                 self.data
                     .raw_dim()
                     .remove_axis(Axis(0))
@@ -543,7 +543,7 @@ mod tests {
             #[test]
             fn $name() {
                 let arr = rand_arr(4usize.pow($dim), (0.0, 1.0), 64)
-                    .into_shape($shape)
+                    .into_shape_with_order($shape)
                     .unwrap();
                 let interp = Interp2D::builder(arr).build().unwrap();
                 let res = interp.interp(2.2, 2.2).unwrap();
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn interp2d_2d_scalar() {
         let arr = rand_arr(4usize.pow(2), (0.0, 1.0), 64)
-            .into_shape((4, 4))
+            .into_shape_with_order((4, 4))
             .unwrap();
         let _res: f64 = Interp2D::builder(arr) // typecheck f64 as return type
             .build()

--- a/tests/interp2d.rs
+++ b/tests/interp2d.rs
@@ -83,17 +83,19 @@ fn extrapolate() {
 
 #[test]
 fn interpolate_array() {
-    let data = Array::linspace(0.0, 8.0, 9).into_shape((3, 3)).unwrap();
+    let data = Array::linspace(0.0, 8.0, 9)
+        .into_shape_with_order((3, 3))
+        .unwrap();
     let x = array![1.0, 2.0, 3.0];
     let y = array![4.0, 5.0, 6.0];
     let resolution = 11usize;
     let qx = Array::linspace(1.0, 3.0, resolution);
     let qy = Array::linspace(4.0, 6.0, resolution);
     let qx = Array::from_iter(qx.into_iter().flat_map(|x| repeat(x).take(resolution)))
-        .into_shape((resolution, resolution))
+        .into_shape_with_order((resolution, resolution))
         .unwrap();
     let qy = Array::from_iter(repeat(qy).take(resolution).flatten())
-        .into_shape((resolution, resolution))
+        .into_shape_with_order((resolution, resolution))
         .unwrap();
 
     let interp = Interp2D::builder(data).x(x).y(y).build().unwrap();
@@ -247,7 +249,7 @@ fn interp_nd_data() {
         .flatten()
         .flatten(),
     )
-    .into_shape((2, 2, 2, 2))
+    .into_shape_with_order((2, 2, 2, 2))
     .unwrap();
 
     let interp = Interp2DBuilder::new(data).build().unwrap();
@@ -265,7 +267,9 @@ fn interp_nd_data() {
 #[test]
 #[should_panic(expected = "`xs.shape()` and `ys.shape()` do not match")]
 fn interp_array_with_unmatched_axis() {
-    let data = Array::linspace(0.0, 8.0, 9).into_shape((3, 3)).unwrap();
+    let data = Array::linspace(0.0, 8.0, 9)
+        .into_shape_with_order((3, 3))
+        .unwrap();
     let qx = array![0.0, 1.0];
     let qy = array![0.0, 1.0, 2.0];
     let interp = Interp2D::builder(data).build().unwrap();


### PR DESCRIPTION
Hey @jonasBoss , thank you for your work on the repo.

I've gone ahead and updated the `ndarray` dependency to 0.16.

This involved the following extra changes:
- When including `ndarray` in the `dev-dependencies` in `Cargo.toml` [the feature flag](https://github.com/jonasBoss/ndarray-interp/pull/8/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21) for `approx` is now just named `approx` rather than `approx-0_5`.
- `.into_shape(...)` is now deprecated, so I've replaced all instances with `.into_shape_with_order(...)`